### PR TITLE
RGB_program_chapter04

### DIFF
--- a/chapter04.rb
+++ b/chapter04.rb
@@ -1,0 +1,10 @@
+def to_hex(red, green, blue)
+  [red, green, blue].inject('#') do |hex, n|
+    hex + n.to_s(16).rjust(2, '0')
+  end
+end
+
+def to_ints(hex)
+  red, green, blue = hex[1..2], hex[3..4], hex[5..6]
+  [red, green, blue].map { |s| s.hex }
+end

--- a/test/rgb_test.rb
+++ b/test/rgb_test.rb
@@ -1,0 +1,16 @@
+require 'minitest/autorun'
+require_relative '../chapter04'
+
+class RgbTest < Minitest::Test
+  def test_to_hex
+    assert_equal '#000000', to_hex(0, 0, 0)
+    assert_equal '#ffffff', to_hex(255, 255, 255)
+    assert_equal '#043c78', to_hex(4, 60, 120)
+  end
+
+  def test_to_ints
+    assert_equal [0, 0, 0], to_ints('#000000')
+    assert_equal [255, 255, 255], to_ints('#ffffff')
+    assert_equal [4, 60, 120], to_ints('#043c78')
+  end
+end


### PR DESCRIPTION
やったこと
---
- RGBプログラムの作成
  - 10進数を16進数に変換するto_hexメソッドと、16進数を10進数に変換するto_intsメソッドを定義する。
  - to_hexメソッドは3つの整数を受け取り、それぞれを16進数に変換した文字列を返す。文字列の先頭には'#'をつける。
  - to_intsメソッドはRGBカラーを表す16進数文字列を受け取り、RGBそれぞれを10進数の整数に変換した値を配列として返す。
  - 上記のテストも書く。