### PR TITLE
ConvertLength_program_chapter05

### DIFF
--- a/chapter05/convert_length.rb
+++ b/chapter05/convert_length.rb
@@ -1,0 +1,4 @@
+UNITS = { m: 1.0, ft: 3.28, in: 39.37 }
+def convert_length(length, from:, to:)
+  (length / UNITS[from] * UNITS[to]).round(2)
+end

--- a/chapter05/convert_length_test.rb
+++ b/chapter05/convert_length_test.rb
@@ -1,0 +1,10 @@
+require 'minitest/autorun'
+require './chapter05/convert_length'
+
+class ConvertLengthTest < Minitest::Test
+  def test_convert_length
+    assert_equal 39.37, convert_length(1, from: :m, to: :in)
+    assert_equal 0.38, convert_length(15, from: :in, to: :m)
+    assert_equal 10670.73, convert_length(35000, from: :ft, to: :m)
+  end
+end


### PR DESCRIPTION
やったこと
---
- 長さの単位変換(convert_length)プログラムの作成
  - メートル(m)、フィート(ft)、インチ(in)の単位を相互に変換する。
  - 第一引数に変換元の長さ、第二引数に変換元の単位、第三引数に変換後の単位を指定する。
  - メソッドの戻り値は変換後の長さとし、端数が出る場合は少数第3位で四捨五入する。
  - 上記のテストも書く。