### PR TITLE
DeepFreeze_method_chapter08

### DIFF
--- a/chapter08/bank.rb
+++ b/chapter08/bank.rb
@@ -1,0 +1,7 @@
+require './chapter08/deep_freezable'
+
+class Bank
+  extend DeepFreezable
+  
+  CURRENCIES = deep_freeze({ 'Japan' => 'yen', 'US' => 'dollar', 'India' => 'rupee' })
+end

--- a/chapter08/deep_freezable.rb
+++ b/chapter08/deep_freezable.rb
@@ -1,0 +1,14 @@
+module DeepFreezable
+  def deep_freeze(array_or_hash)
+    case array_or_hash
+    when Array
+      array_or_hash.each { |element| element.freeze }
+    when Hash
+      array_or_hash.each do |key, value|
+        key.freeze
+        value.freeze
+      end
+    end
+    array_or_hash.freeze
+  end
+end

--- a/chapter08/deep_freezable_test.rb
+++ b/chapter08/deep_freezable_test.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+require './chapter08/team'
+require './chapter08/bank'
+
+class DeepFreezableTest < Minitest::Test
+  def test_deep_freeze_to_array
+    assert_equal ['Japan', 'US', 'India'], Team::COUNTRIES
+    assert Team::COUNTRIES.frozen?
+    assert Team::COUNTRIES.all? { |country| country.frozen? }
+  end
+
+  def test_deep_freeze_to_hash
+    assert_equal(
+      { 'Japan' => 'yen', 'US' => 'dollar', 'India' => 'rupee' },
+      Bank::CURRENCIES
+    )
+    assert Bank::CURRENCIES.frozen?
+    assert Bank::CURRENCIES.all? { |key, value| key.frozen? && value.frozen? }
+  end
+end

--- a/chapter08/team.rb
+++ b/chapter08/team.rb
@@ -1,0 +1,7 @@
+require './chapter08/deep_freezable'
+
+class Team
+  extend DeepFreezable
+
+  COUNTRIES = deep_freeze(['Japan', 'US', 'India'])
+end

--- a/spec/deep_freezable_spec.rb
+++ b/spec/deep_freezable_spec.rb
@@ -1,0 +1,20 @@
+require './chapter08/deep_freezable'
+
+RSpec.describe DeepFreezable do
+  include DeepFreezable
+  
+  let(:countries) { ['Japan', 'US', 'India'] }
+  let(:currencies) { { 'Japan' => 'yen', 'US' => 'dollar', 'India' => 'rupee' } }
+
+  describe '#deep_freeze' do
+    it '配列自身(countries)と配列の各要素(country)がfreezeされる' do
+      expect(deep_freeze(countries).frozen?).to be_truthy
+      expect(deep_freeze(countries).all? { |country| country.frozen? }).to be_truthy
+    end
+
+    it 'ハッシュ自身(currencies)とハッシュの各要素(key,value)がfreezeされる' do
+      expect(deep_freeze(currencies).frozen?).to be_truthy
+      expect(deep_freeze(currencies).all? { |key, value| key.frozen? && value.frozen? }).to be_truthy
+    end
+  end
+end

--- a/spec/deep_freezable_spec.rb
+++ b/spec/deep_freezable_spec.rb
@@ -2,19 +2,19 @@ require './chapter08/deep_freezable'
 
 RSpec.describe DeepFreezable do
   include DeepFreezable
-  
-  let(:countries) { ['Japan', 'US', 'India'] }
-  let(:currencies) { { 'Japan' => 'yen', 'US' => 'dollar', 'India' => 'rupee' } }
+
+  let(:array) { ['Japan', 'US', 'India'] }
+  let(:hash) { { 'Japan' => 'yen', 'US' => 'dollar', 'India' => 'rupee' } }
 
   describe '#deep_freeze' do
-    it '配列自身(countries)と配列の各要素(country)がfreezeされる' do
-      expect(deep_freeze(countries).frozen?).to be_truthy
-      expect(deep_freeze(countries).all? { |country| country.frozen? }).to be_truthy
+    it '配列自身(array)と配列の各要素(element)がfreezeされる' do
+      expect(deep_freeze(array).frozen?).to be_truthy
+      expect(deep_freeze(array).all? { |element| element.frozen? }).to be_truthy
     end
 
-    it 'ハッシュ自身(currencies)とハッシュの各要素(key,value)がfreezeされる' do
-      expect(deep_freeze(currencies).frozen?).to be_truthy
-      expect(deep_freeze(currencies).all? { |key, value| key.frozen? && value.frozen? }).to be_truthy
+    it 'ハッシュ自身(hash)とハッシュの各要素(key,value)がfreezeされる' do
+      expect(deep_freeze(hash).frozen?).to be_truthy
+      expect(deep_freeze(hash).all? { |key, value| key.frozen? && value.frozen? }).to be_truthy
     end
   end
 end


### PR DESCRIPTION
やったこと
---
- deep_freezeメソッドの作成
  - 配列やハッシュを引数として渡すと、配列やハッシュ自身に加えてそれらの各要素を全てfreezeさせる。
    - 作成するメソッドは特定のクラスだけでなく様々なクラスから呼べることとする。
    - メソッドの引数は配列もしくはハッシュのみとする。
    - 引数の配列やハッシュはフラットな構造にする。（ネストするケースは考慮しない）
  - 上記のテストをminitestで書く。
  - 同メソッドのテストをRSpecで書く。